### PR TITLE
Feature: search in invoices

### DIFF
--- a/src/Resource/AuthorizedPaymentResource.php
+++ b/src/Resource/AuthorizedPaymentResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WandesCardoso\MercadoPago\Resource;
+
+use Ramsey\Uuid\Uuid;
+use WandesCardoso\MercadoPago\DTO\Payment;
+use WandesCardoso\MercadoPago\DTO\PaymentUpdate;
+
+final class AuthorizedPaymentResource extends MpResource
+{
+    protected string $baseUri = '/authorized_payments';
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public function search(array $params): array
+    {
+        return $this->get("/{$this->baseUri}/search", $params);
+    }
+
+    /** @return array<string, mixed> */
+    public function find(string $id): array
+    {
+        return $this->get("/{$this->baseUri}/{$id}");
+    }
+}

--- a/src/Resource/InvoiceResource.php
+++ b/src/Resource/InvoiceResource.php
@@ -2,11 +2,7 @@
 
 namespace WandesCardoso\MercadoPago\Resource;
 
-use Ramsey\Uuid\Uuid;
-use WandesCardoso\MercadoPago\DTO\Payment;
-use WandesCardoso\MercadoPago\DTO\PaymentUpdate;
-
-final class AuthorizedPaymentResource extends MpResource
+final class InvoiceResource extends MpResource
 {
     protected string $baseUri = '/authorized_payments';
 

--- a/src/Traits/MpRequest.php
+++ b/src/Traits/MpRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WandesCardoso\MercadoPago\Traits;
 
-use WandesCardoso\MercadoPago\Resource\AuthorizedPaymentResource;
+use WandesCardoso\MercadoPago\Resource\InvoiceResource;
 use WandesCardoso\MercadoPago\Resource\MpResource;
 use WandesCardoso\MercadoPago\Resource\PaymentResource;
 use WandesCardoso\MercadoPago\Resource\PlanResource;
@@ -23,9 +23,9 @@ trait MpRequest
         return new PaymentResource($this);
     }
 
-    public function authorized_payment(): AuthorizedPaymentResource
+    public function invoice(): InvoiceResource
     {
-        return new AuthorizedPaymentResource($this);
+        return new InvoiceResource($this);
     }
 
     public function preference(): PreferenceResource

--- a/src/Traits/MpRequest.php
+++ b/src/Traits/MpRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WandesCardoso\MercadoPago\Traits;
 
+use WandesCardoso\MercadoPago\Resource\AuthorizedPaymentResource;
 use WandesCardoso\MercadoPago\Resource\MpResource;
 use WandesCardoso\MercadoPago\Resource\PaymentResource;
 use WandesCardoso\MercadoPago\Resource\PlanResource;
@@ -20,6 +21,11 @@ trait MpRequest
     public function payment(): PaymentResource
     {
         return new PaymentResource($this);
+    }
+
+    public function authorized_payment(): AuthorizedPaymentResource
+    {
+        return new AuthorizedPaymentResource($this);
     }
 
     public function preference(): PreferenceResource

--- a/tests/Feature/Resource/InvoiceResourceTest.php
+++ b/tests/Feature/Resource/InvoiceResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use WandesCardoso\MercadoPago\MercadoPago as Mp;
+
+it('can get a subscription authorized payment', function () {
+    $mockClient = mockClient('invoice/find');
+
+    $response = Mp::make(getAccessToken())->withMockClient($mockClient)->invoice()->find('1234567890');
+
+    expect($response)->toBeArray()
+        ->and($response['httpCode'])->toEqual(200)
+        ->and($response['body']->id)->toBe(1234567890)
+        ->and($response['body']->status)->toBe('processed')
+        ->and($response['body']->payment->id)->toBe(1234567890)
+        ->and($response['body']->payment->status)->toBe('approved');
+});
+
+it('can search a subscription authorized payment', function () {
+    $mockClient = mockClient('invoice/search');
+
+    $params = [
+        'preapproval_id' => '1234567890'
+    ];
+
+    $response = Mp::make(getAccessToken())->withMockClient($mockClient)->invoice()->search($params);
+
+    expect($response)->toBeArray()
+        ->and($response['httpCode'])->toEqual(200)
+        ->and($response['body']->results)->toBeArray()->toHaveLength(1)
+        ->and($response['body']->results[0]->id)->toBe(1234567890)
+        ->and($response['body']->results[0]->status)->toBe('processed')
+        ->and($response['body']->results[0]->payment->id)->toBe(1234567890)
+        ->and($response['body']->results[0]->payment->status)->toBe('approved');
+});

--- a/tests/Fixtures/Mp/invoice/find.json
+++ b/tests/Fixtures/Mp/invoice/find.json
@@ -1,0 +1,20 @@
+{
+    "preapproval_id": "1234567890",
+    "id": 1234567890,
+    "type": "recurring",
+    "status": "processed",
+    "date_created": "2024-06-06T16:58:12.279-04:00",
+    "last_modified": "2024-06-06T17:01:14.352-04:00",
+    "transaction_amount": 89.99,
+    "currency_id": "BRL",
+    "reason": "Teste Subscription",
+    "payment": {
+        "id": 1234567890,
+        "status": "approved",
+        "status_detail": "accredited"
+    },
+    "retry_attempt": 1,
+    "next_retry_date": "2024-06-07T16:56:38.000-04:00",
+    "debit_date": "2024-06-06T16:56:37.000-04:00",
+    "payment_method_id": "card"
+}

--- a/tests/Fixtures/Mp/invoice/search.json
+++ b/tests/Fixtures/Mp/invoice/search.json
@@ -1,0 +1,29 @@
+{
+    "results": [
+        {
+            "preapproval_id": "1234567890",
+            "id": 1234567890,
+            "type": "recurring",
+            "status": "processed",
+            "date_created": "2024-06-06T16:58:12.279-04:00",
+            "last_modified": "2024-06-06T17:01:14.352-04:00",
+            "transaction_amount": 89.99,
+            "currency_id": "BRL",
+            "reason": "Teste Subscription",
+            "payment": {
+                "id": 1234567890,
+                "status": "approved",
+                "status_detail": "accredited"
+            },
+            "retry_attempt": 1,
+            "next_retry_date": "2024-06-07T16:56:38.000-04:00",
+            "debit_date": "2024-06-06T16:56:37.000-04:00",
+            "payment_method_id": "card"
+        }
+    ],
+    "paging": {
+        "offset": 0,
+        "limit": 12,
+        "total": 1
+    }
+}


### PR DESCRIPTION
I've created the `authorized_payment` method to get information about a authorized payment. 

### Usage: 
One of these parameters are required: `id`, `preapproval_id`, `payment_id` or `payer_id`
```
mercadoPago()->authorized_payment()->search([
    'id' => $id,
    'preapproval_id' => $preapproval_id,
    'payment_id' => $payment_id,
    'payer_id' => $payer_id,
]);
```
By ID
```
mercadoPago()->authorized_payment()->find($id);
```


Official API reference: [click here](https://www.mercadopago.com.br/developers/pt/reference/subscriptions/_authorized_payments_search/get)